### PR TITLE
patch: Hidden cover active default

### DIFF
--- a/src/page/config.ts
+++ b/src/page/config.ts
@@ -86,6 +86,10 @@ export const localConfig: LocalConfig = (() => {
         [role='main'] ~ div {
           display: none;
         }
+        /* cover default spotify */
+        [data-testid='CoverSlotExpanded__container'] {
+          display: none;
+        }
         .${LYRICS_CLASSNAME}::before {
           content: '\\f345';
           font-size: 16px;


### PR DESCRIPTION
Prevents keeping both covers active.
You can find a better solution (like toogle) to disappear only when you activate the letters, but I haven't found the starting point.
Good plugin!